### PR TITLE
 Use GetExtent method for envelope

### DIFF
--- a/acolite/shared/polygon_limit.py
+++ b/acolite/shared/polygon_limit.py
@@ -3,15 +3,13 @@
 ## written by Quinten Vanhellemont, RBINS
 ## 2021-02-23
 ## modifications:
+## 2021-10-21 (shundt@usgs.gov): Use GetExtent method for envelope. This works for single and multi-polygon 
 
 def polygon_limit(poly):
     from osgeo import ogr,osr,gdal
-    env = None
     vector_ds = ogr.Open(poly)
     lyr = vector_ds.GetLayer()
-    for feature in lyr:
-        geom=feature.GetGeometryRef()
-        if env is None: env = geom.GetEnvelope()
+    env = lyr.GetExtent()
     vector_ds = None
     limit = [env[2], env[0], env[3], env[1]]
     return(limit)


### PR DESCRIPTION
This works for single and multi-polygon. Prior implementation would only use the limit from the first item of a multi-polygon file and would thus not allow for use of multiple polygon masks simultaneously. I've tested this for a few Sentinel-2 tiles in the US in which I masked using multiple waterbodies from the National Hydrography Dataset.  