### PR TITLE
Fix #50

### DIFF
--- a/acolite/pleiades/metadata_parse.py
+++ b/acolite/pleiades/metadata_parse.py
@@ -32,8 +32,8 @@ def metadata_parse(metafile, pan=False):
     for tag in metadata_tags:
         node = xmldoc.getElementsByTagName(tag)
         if len(node) > 0:
-            if not node[0].firstChild is None:
-                metadata[tag] = node[0].firstChild.nodeValue
+            if node[0].firstChild is None: continue
+            metadata[tag] = node[0].firstChild.nodeValue
     metadata['sensor'] = '{}{}'.format(metadata['MISSION'],metadata['MISSION_INDEX'])
     if 'SPOT' in metadata['sensor']: metadata['satellite'] = 'SPOT'
 

--- a/acolite/pleiades/metadata_parse.py
+++ b/acolite/pleiades/metadata_parse.py
@@ -31,7 +31,9 @@ def metadata_parse(metafile, pan=False):
                      'RED_CHANNEL', 'GREEN_CHANNEL', 'BLUE_CHANNEL', 'ALPHA_CHANNEL', 'EXTENT_TYPE']
     for tag in metadata_tags:
         node = xmldoc.getElementsByTagName(tag)
-        if len(node) > 0: metadata[tag] = node[0].firstChild.nodeValue
+        if len(node) > 0:
+            if not node[0].firstChild is None:
+                metadata[tag] = node[0].firstChild.nodeValue
     metadata['sensor'] = '{}{}'.format(metadata['MISSION'],metadata['MISSION_INDEX'])
     if 'SPOT' in metadata['sensor']: metadata['satellite'] = 'SPOT'
 


### PR DESCRIPTION
This change should fix reading PHR file metadata in a case when the metadata contain empty element, such as in this situation: 
```
<Band_Display_Order>
                <RED_CHANNEL>P</RED_CHANNEL>
                <GREEN_CHANNEL>P</GREEN_CHANNEL>
                <BLUE_CHANNEL>P</BLUE_CHANNEL>
                <ALPHA_CHANNEL></ALPHA_CHANNEL>
</Band_Display_Order>
```