### PR TITLE
Add .gitignore to untrack LUT and MET data and compiled files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Specifies untracked files that git should ignore
+
+#--------------------------------------------------------------------
+# Specific to ACOLITE
+
+data/LUT/
+data/MET/
+
+#--------------------------------------------------------------------
+# Specific to python
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class


### PR DESCRIPTION
Hi,

Currently, when running ACOLITE using the source code folder, `git status` calls are polluted by the contents of the `data/LUT` and `data/MET` folders, as well as python compiled files (for example `__pycache__`).

This can be avoided by adding a `.gitignore` file.

Please let me know if you think it can be useful !