### PR TITLE
Check if dir instead of exsistance to allow submodule import

### DIFF
--- a/acolite/__init__.py
+++ b/acolite/__init__.py
@@ -70,7 +70,7 @@ else:
 
     gitdir = '{}/.git'.format(path)
     gd = {}
-    if os.path.exists(gitdir):
+    if os.path.isdir(gitdir):
         gitfiles = os.listdir(gitdir)
 
         for f in ['ORIG_HEAD', 'FETCH_HEAD', 'HEAD']:


### PR DESCRIPTION
# Description

When including the acolite repo in your project as a submodule you might encounter an issue with the `.git` folder not being a folder. This PR checks for whether or not `.git` is an existing folder, as opposed to if it exists or not. With this change I was able to import the python modules as well as launch acolite without problems. 