### PR TITLE
Mb 20240423 maintenance

### DIFF
--- a/acolite/acolite/acolite_l2r.py
+++ b/acolite/acolite/acolite_l2r.py
@@ -92,6 +92,7 @@ def acolite_l2r(gem,
         hyper = True
         rsr = ac.shared.rsr_hyper(gem.gatts['band_waves'], gem.gatts['band_widths'], step=0.1)
         rsrd = ac.shared.rsr_dict(rsrd={gem.gatts['sensor']:{'rsr':rsr}})
+        del rsr
     else:
         rsrd = ac.shared.rsr_dict(gem.gatts['sensor'])
 
@@ -122,6 +123,7 @@ def acolite_l2r(gem,
                 if (setu['pressure'] != setu['pressure_default']): continue
             if (k == 'wind') & (setu['wind'] is not None): continue
             if k in anc: gem.gatts[k] = 1.0 * anc[k]
+        del clon, clat, anc
     else:
         if (setu['s2_auxiliary_default']) & (gem.gatts['sensor'][0:2] == 'S2') & (gem.gatts['sensor'][4:] == 'MSI'):
             ## get mid point values from AUX ECMWFT
@@ -151,9 +153,11 @@ def acolite_l2r(gem,
                                                                    gem.gatts['AUX_{}_latitudes'.format(aux_par)]),
                                                                    gem.gatts['AUX_{}_values'.format(aux_par)])
                     gem.gatts['pressure'] = lndi(clon, clat)/100 # convert from Pa to hPa
+                    del lndi
                 elif 'msl' in gem.datasets:  # S2Resampling, msiresampling
                     lndi = gem.data('msl')
                     gem.gatts['pressure'] = lndi(lndi.len/2, lndi.len/2) / 100  # convert from Pa to hPa
+                    del lndi
                 ## ozone
                 aux_par = 'ECMWFT_tco3'
                 if 'AUX_{}_values'.format(aux_par) in gem.gatts:
@@ -161,6 +165,7 @@ def acolite_l2r(gem,
                                                                    gem.gatts['AUX_{}_latitudes'.format(aux_par)]),
                                                                    gem.gatts['AUX_{}_values'.format(aux_par)])
                     gem.gatts['uoz'] = lndi(clon, clat)**-1 * 0.0021415 # convert from kg/m2 to cm-atm
+                    del lndi
                 ## water vapour
                 aux_par = 'ECMWFT_tcwv'
                 if 'AUX_{}_values'.format(aux_par) in gem.gatts:
@@ -168,9 +173,12 @@ def acolite_l2r(gem,
                                                                    gem.gatts['AUX_{}_latitudes'.format(aux_par)]),
                                                                    gem.gatts['AUX_{}_values'.format(aux_par)])
                     gem.gatts['uwv'] = lndi(clon, clat)/10 # convert from kg/m2 to g/cm2
+                    del lndi
                 elif 'tcwv' in gem.datasets:
                     lndi = gem.data('tcwv')
                     gem.gatts['uwv'] = lndi(lndi.len/2, lndi.len/2) / 10  # convert from kg/m2 to g/cm2
+                    del lndi
+                del clon, clat
 
     ## elevation provided
     if setu['elevation'] is not None:
@@ -287,6 +295,7 @@ def acolite_l2r(gem,
                     if setu['gas_transmittance'] is False: gem.bands[b][k] = 1.0
             gem.bands[b]['wavelength']=gem.bands[b]['wave_nm']
     ## end bands dataset
+    del rhot_ds, tg_dict
 
     ## atmospheric correction
     if setu['aerosol_correction'] == 'dark_spectrum':
@@ -313,6 +322,7 @@ def acolite_l2r(gem,
             gem.data_mem[ds] = geom_mean[ds]
         else:
             tmp = gem.data(ds, store=True)
+            del tmp
         if len(np.atleast_1d(gem.data(ds)))>1:
             use_revlut=True ## if any dataset more than 1 dimension use revlut
             per_pixel_geometry = True
@@ -321,6 +331,8 @@ def acolite_l2r(gem,
             gem.data_mem[ds].shape+=(1,1)
         gem.data_mem['{}_mean'.format(ds)] = np.asarray(np.nanmean(gem.data(ds))) ## also store tile mean
         gem.data_mem['{}_mean'.format(ds)].shape+=(1,1) ## make 1,1 dimensions
+
+    del geom_mean
 
     ## for tiled processing track tile positions and average geometry
     tiles = []
@@ -369,6 +381,7 @@ def acolite_l2r(gem,
         segment_data = {}
         rhot_ds = [ds for ds in gem.datasets if 'rhot_' in ds]
         finite_mask = np.isfinite(gem.data(rhot_ds[0]))
+        del rhot_ds
         segment_mask = skimage.measure.label(finite_mask)
         segments = np.unique(segment_mask)
 
@@ -1369,6 +1382,7 @@ def acolite_l2r(gem,
                     romix[segment_data[segment]['sub']] = romix_[sidx]
                     astot[segment_data[segment]['sub']] = astot_[sidx]
                     dutott[segment_data[segment]['sub']] = dutott_[sidx]
+                del romix_, astot_, dutott_
 
             ## write ac parameters
             if setu['dsf_write_tiled_parameters']:
@@ -1435,9 +1449,11 @@ def acolite_l2r(gem,
                                         lutdw[luts[0]]['meta']['wave'], xi[1], xi[2], xi[3], xi[4], 0.001)).flatten()
                     rorayl_cur = ac.shared.rsr_convolute_nd(rorayl_hyper, lutdw[luts[0]]['meta']['wave'], rsrd['rsr'][b]['response'], rsrd['rsr'][b]['wave'], axis=0)
                     dutotr_cur = ac.shared.rsr_convolute_nd(dutotr_hyper, lutdw[luts[0]]['meta']['wave'], rsrd['rsr'][b]['response'], rsrd['rsr'][b]['wave'], axis=0)
+                    del rorayl_hyper, dutotr_hyper
                 else:
                     rorayl_cur = lutdw[luts[0]]['rgi'][b]((xi[0], lutdw[luts[0]]['ipd'][par], xi[1], xi[2], xi[3], xi[4], 0.001))
                     dutotr_cur = lutdw[luts[0]]['rgi'][b]((xi[0], lutdw[luts[0]]['ipd']['dutott'], xi[1], xi[2], xi[3], xi[4], 0.001))
+                del xi
 
             ## create full scene parameters for segmented processing
             if setu['dsf_aot_estimate'] == 'segmented':
@@ -1448,6 +1464,7 @@ def acolite_l2r(gem,
                 for sidx, segment in enumerate(segment_data):
                     rorayl_cur[segment_data[segment]['sub']] = rorayl_[sidx]
                     dutotr_cur[segment_data[segment]['sub']] = dutotr_[sidx]
+                del rorayl_, dutotr_
 
             ## create full scene parameters for tiled processing
             if (setu['dsf_aot_estimate'] == 'tiled') & (use_revlut):
@@ -1473,6 +1490,9 @@ def acolite_l2r(gem,
             cur_rhorc = (cur_rhorc - rorayl_cur) / (dutotr_cur)
             gemo.write(dso.replace('rhos_', 'rhorc_'), cur_rhorc, ds_att = ds_att)
             del cur_rhorc, rorayl_cur, dutotr_cur
+
+        if ac_opt == 'dsf' and setu['slicing']:
+            del valid_mask
 
         ## write rhos
         gemo.write(dso, cur_data, ds_att = ds_att)

--- a/acolite/acolite/acolite_l2r.py
+++ b/acolite/acolite/acolite_l2r.py
@@ -14,7 +14,6 @@
 ##                2023-12-07 (QV) option to use S2 AUX
 ##                2024-03-14 (QV) update settings handling
 ##                2024-04-23 (MB) use ancillary data included in resampled MSI
-import math
 
 
 def acolite_l2r(gem,
@@ -136,7 +135,7 @@ def acolite_l2r(gem,
             if 'AUX_ECMWFT__0u_values' in gem.gatts and 'AUX_ECMWFT__0v_values' in gem.gatts:  # S2Resampling, msiresampling
                 u_wind = gem.gatts['AUX_ECMWFT__0u_values'][int(len(gem.gatts['AUX_ECMWFT__0u_values'])/2)]
                 v_wind = gem.gatts['AUX_ECMWFT__0v_values'][int(len(gem.gatts['AUX_ECMWFT__0v_values'])/2)]
-                gem.gatts['wind'] = math.sqrt(u_wind * u_wind + v_wind * v_wind)
+                gem.gatts['wind'] = np.sqrt(u_wind * u_wind + v_wind * v_wind)
 
             ## interpolate to scene centre
             if setu['s2_auxiliary_interpolate']:

--- a/acolite/s2resampling/l1_convert.py
+++ b/acolite/s2resampling/l1_convert.py
@@ -4,6 +4,7 @@
 ## 2023-05-02
 ## modifications: 2023-07-12 (QV) removed netcdf_compression settings from nc_write call
 ##                2024-04-17 (QV) use new gem NetCDF handling
+##                2024-04-23 (MB) read ancillary data of resampled input if requested
 
 def l1_convert(inputfile, output = None, settings = {}, verbosity = 5):
     import numpy as np
@@ -32,9 +33,10 @@ def l1_convert(inputfile, output = None, settings = {}, verbosity = 5):
         setu = ac.acolite.settings.parse(sensor, settings=settings)
         output = setu['output']
         if output is None:
-            odir = os.path.dirname(imagefile)
+            odir = os.path.dirname(bundle)
         else:
             odir = output
+        s2_auxiliary_default = setu['s2_auxiliary_default']
 
 #     ## check if ROI polygon is given
 #     clip, clip_mask = False, None
@@ -120,5 +122,59 @@ def l1_convert(inputfile, output = None, settings = {}, verbosity = 5):
                 gemo.write(dso, d)
         gemi.close()
         gemo.close()
+
+        ## auxiliary data, S2Resampling or msiresampling
+        if s2_auxiliary_default:
+            try:
+                datasets = ac.shared.nc_datasets(bundle)
+                # msiresampling can interpolate ancillary to each pixel
+                if 'tcwv_interpolated' in datasets \
+                        and 'msl_interpolated' in datasets \
+                        and 'tco3_interpolated' in datasets \
+                        and 'u10_interpolated' in datasets \
+                        and 'v10_interpolated' in datasets:
+                    for source,name,b in [('AUX_ECMWFT', 'tcwv', 'tcwv'),
+                                          ('AUX_ECMWFT', 'msl', 'msl'),
+                                          ('AUX_ECMWFT', 'tco3', 'tco3'),
+                                          ('AUX_ECMWFT', 'u10', '_0u'),
+                                          ('AUX_ECMWFT', 'v10', '_0v')]:
+                        data = ac.shared.nc_data(bundle, f"{name}_interpolated")
+                        height, width = data.shape
+                        # ACOLITE so far uses a single ancillary value only and does not interpolate to the pixels.
+                        # An array is expected in values, it is the central value that will be selected
+                        gatts['{}_{}_{}'.format(source, b, 'dimensions')] = (3, 1)
+                        gatts['{}_{}_{}'.format(source, b, 'values')] = [data[0, 0], data[height//2, width//2], data[-1, -1]]
+                        gatts['{}_{}_{}'.format(source, b, 'longitudes')] = []
+                        gatts['{}_{}_{}'.format(source, b, 'latitudes')] = []
+                        del data
+                    ac.shared.nc_gatts_update(ofile, gatts)
+                    print(f"using embedded ECMWF ancillary data available on pixel resolution")
+                else:
+                    # S2Resampling in a patched version provides lat and lon for the ancillary data grid.
+                    # A ticket is open to add this behaviour to SNAP.
+                    # Until then s2_auxiliary_default must be used with s2_auxiliary_interpolate=False
+                    try:
+                        lat = ac.shared.nc_data(bundle, 'aux_latitude')
+                        lon = ac.shared.nc_data(bundle, 'aux_longitude')
+                    except Exception as e:
+                        print("no aux_latitude and aux_longitude in tie-points. Use Calvalus S2 reader: {e}")
+                        lat = []
+                        lon = []
+                    for source,b in [('AUX_ECMWFT', 'tcwv'),
+                                     ('AUX_ECMWFT', 'msl'),
+                                     ('AUX_ECMWFT', 'tco3'),
+                                     ('AUX_ECMWFT', '_0u'),
+                                     ('AUX_ECMWFT', '_0v')]:
+                        data = ac.shared.nc_data(bundle, b)
+                        gatts['{}_{}_{}'.format(source, b, 'dimensions')] = data.shape
+                        gatts['{}_{}_{}'.format(source, b, 'values')] = data.flatten()
+                        gatts['{}_{}_{}'.format(source, b, 'longitudes')] = lon.flatten()
+                        gatts['{}_{}_{}'.format(source, b, 'latitudes')] = lat.flatten()
+                    ac.shared.nc_gatts_update(ofile, gatts)
+                    print(f"using embedded ECMWF ancillary data available on coarse geographic grid")
+            except Exception as e:
+                print(f"cannot use embedded ECMWF data: {e}")
+                raise e
+
         ofiles.append(ofile)
     return(ofiles, setu)

--- a/acolite/s2resampling/l1_convert.py
+++ b/acolite/s2resampling/l1_convert.py
@@ -141,11 +141,11 @@ def l1_convert(inputfile, output = None, settings = {}, verbosity = 5):
                                           ('AUX_ECMWFT', 'u10_interpolated', '_0u'),
                                           ('AUX_ECMWFT', 'v10_interpolated', '_0v')]:
                         data = ac.shared.nc_data(bundle, name)
-                        height, width = data.shape
+                        median = np.median(data.compressed())
                         # ACOLITE so far uses a single ancillary value only and does not interpolate to the pixels.
                         # An array is expected in values, it is the central value that will be selected
                         gatts['{}_{}_{}'.format(source, b, 'dimensions')] = (3, 1)
-                        gatts['{}_{}_{}'.format(source, b, 'values')] = [data[0, 0], data[height//2, width//2], data[-1, -1]]
+                        gatts['{}_{}_{}'.format(source, b, 'values')] = [median, median, median]
                         gatts['{}_{}_{}'.format(source, b, 'longitudes')] = []
                         gatts['{}_{}_{}'.format(source, b, 'latitudes')] = []
                         del data


### PR DESCRIPTION
Dear Quinten,

there are some improvements since 2024-02-20 when I had pulled the "new" version of ACOLITE. Runtime is shorter, 8 minutes instead of 11 on a HR-OC 6*8 degrees tile. That is fine. 

I have added two commits that help me processing the resampled product using ancillary data embedded in the MSI L1C. It may be possible to do this at an earlier stage to avoid the update of the NetCDF file, but I did not want to modify your code too much. I am not sure the addition is relevant for other users than HR-OC. If you do not want to include it I can maintain it in a branch of my fork.

There is one more commit with additional del statements. Python does not detect that a variable will not be used any more and blocks the respective storage longer than necessary. This is particularly relevant for linear code like yours with many lines in a function.

Best regards,
Martin