### PR TITLE
Modification to deal with gdal version 3.10.1. 

### DIFF
--- a/acolite/output/nc_to_geotiff_rgb.py
+++ b/acolite/output/nc_to_geotiff_rgb.py
@@ -17,7 +17,8 @@ def nc_to_geotiff_rgb(f, settings = None, use_gdal_merge_import = True, remove_t
     import numpy as np
     from osgeo import gdal
     gdal.DontUseExceptions()
-    if gdal.__version__ < '3.3':
+    from packaging import version
+    if version.parse(gdal.__version__) < version.parse('3.3'):
         from osgeo.utils import gdal_merge
     else:
         from osgeo_utils import gdal_merge


### PR DESCRIPTION
The error come from the line 20 where

if gdal.__version__ < '3.3':
will yield TRUE for gdal.__version__='3.10.1'
because we are comparing strings.

