### PR TITLE
Mistake in /acolite/output/project_acolite_netcdf.py

### DIFF
--- a/acolite.spec
+++ b/acolite.spec
@@ -22,6 +22,7 @@ hiddenimports+=['cftime']
 hiddenimports+=['pywt._extensions._cwt']
 hiddenimports+=['scipy.spatial.transform._rotation_groups', 'cmath']
 hiddenimports+=['pyhdf.six']
+hiddenimports+=['pyresample']
 
 a = Analysis(['launch_acolite.py'],
              binaries=[],

--- a/acolite/output/project_acolite_netcdf.py
+++ b/acolite/output/project_acolite_netcdf.py
@@ -79,7 +79,7 @@ def project_acolite_netcdf(ncf, output = None, settings = None, target_file=None
     if (setu['output_projection_limit'] is None):
         ## read lat/lon
         lat = gem.data('lat') #ac.shared.nc_data(ncf, 'lat')
-        lon = gem.data('lat') #ac.shared.nc_data(ncf, 'lon')
+        lon = gem.data('lon') #ac.shared.nc_data(ncf, 'lon')
         setu['output_projection_limit'] = [np.nanmin(lat), np.nanmin(lon), np.nanmax(lat), np.nanmax(lon)]
         print('Output limit from lat/lon', setu['output_projection_limit'])
 


### PR DESCRIPTION
There is a serious mistake in the source code. In line 82 of "./acolite/output/project_acolite_netcdf.py", "lon = gem.data('lat')"causes the full granule to be unable to be processed when the **limit** parameter is set to None.