### PR TITLE
Fix polygon given as WKT string

### DIFF
--- a/acolite/acolite/settings/read.py
+++ b/acolite/acolite/settings/read.py
@@ -28,7 +28,10 @@ def read(file):
                 ## store settings
                 split = [s.strip() for s in split]
                 var = split[0]
-                val = [s.strip() for s in split[1].split(',')]
+                if var == 'polygon':
+                    val = split[1]  # WKT string
+                else:
+                    val = [s.strip() for s in split[1].split(',')]
                 if len(val) == 1:
                     val = val[0]
                     if val in ['True','true']: val=True


### PR DESCRIPTION
Hi Quinten,

When we define `polygon` (in the settings file) as a WKT string and not as a GeoJSON file, this setting is currently not loaded correctly: it is parsed as a list (e.g. `["POLYGON ((1 10", "2 10", "2 11", "1 11", "1 10))"]`) instead of a well-formatted WKT string (e.g. `"POLYGON ((1 10, 2 10, 2 11, 1 11, 1 10))"`).
This PR solves this issue ;)

++