### PR TITLE
PGC data compatibility improvements

### DIFF
--- a/acolite/output/nc_to_geotiff.py
+++ b/acolite/output/nc_to_geotiff.py
@@ -19,6 +19,7 @@
 ##                2025-05-21 (QV) update settings parsing
 ##                2025-07-28 (QV) use export_geotiff_use_projection_key from settings
 ##                2026-05-04 (QV) removed PixelIsPoint update
+##                2026-06-11 (DP) use gdal.Warp instead of gdal.Translate for better nodata handling
 
 def nc_to_geotiff(f, settings = None, datasets = None):
     import acolite as ac
@@ -66,9 +67,20 @@ def nc_to_geotiff(f, settings = None, datasets = None):
             if ds in ['x', 'y', gem.gatts['projection_key']]: continue
             if (skip_geo) & (ds in ['lat', 'lon']): continue
             outfile = '{}_{}{}'.format(out, ds, '.tif')
+
+            # When _FillValue or missing_value are not defined in the netCDF file, the
+            # underlying netCDF reading library GDAL uses will convert NaN values to a
+            # default value based on the data type (e.g. 9.969209968386869e+36 for floats).
+            # This code block reads that value so that we can instruct gdal.Warp to:
+            #     NaN in netCDF -> default/fill value in memory -> NaN in GeoTiff
+            with gdal.Open('NETCDF:"{}":{}'.format(f, ds)) as dataset:
+                band = dataset.GetRasterBand(1)
+                src_nodata = band.GetNoDataValue()
+
             ## write geotiff
-            dt = gdal.Translate(outfile, 'NETCDF:"{}":{}'.format(f, ds),
-                                noData = np.nan,
+            dt = gdal.Warp(outfile, 'NETCDF:"{}":{}'.format(f, ds),
+                                srcNodata=src_nodata, dstNodata=np.nan,
+                                resampleAlg=gdal.GRA_NearestNeighbour,
                                 format = format, creationOptions = creationOptions)
             dt = None
             print('Wrote {}'.format(outfile))

--- a/acolite/worldview/l1_convert.py
+++ b/acolite/worldview/l1_convert.py
@@ -18,6 +18,7 @@
 ##                2025-04-07 (QV) change worldview_convert_l2 to convert_l2
 ##                2025-09-15 (QV) added rpc_use = False
 ##                2026-01-15 (QV) changed to rsr_dict, added basic support for PAN processing
+##                2026-06-11 (DP) improve handling of PGC distributed and/or processed imagery
 
 def l1_convert(inputfile, output = None, inputfile_swir = None, settings = None):
 

--- a/acolite/worldview/l1_convert.py
+++ b/acolite/worldview/l1_convert.py
@@ -316,6 +316,9 @@ def l1_convert(inputfile, output = None, inputfile_swir = None, settings = None)
             #print(dct['xdim'], dct['ydim'])
             #print(dct['xrange'], dct['yrange'])
 
+            ## update the global dimensions to match the computed dimensions
+            global_dims = dct['ydim'], dct['xdim']
+
             ## create pan version
             if pan_bundle is not None:
                 dct_pan = {k:dct[k] for k in dct}

--- a/acolite/worldview/l1_convert.py
+++ b/acolite/worldview/l1_convert.py
@@ -112,16 +112,18 @@ def l1_convert(inputfile, output = None, inputfile_swir = None, settings = None)
                 print('Image {} is already corrected by supplier.'.format(bundle))
                 print('RADIOMETRICLEVEL: {} RADIOMETRICENHANCEMENT: {}'.format(meta['RADIOMETRICLEVEL'], meta['RADIOMETRICENHANCEMENT']))
                 atmospherically_corrected = True
+                correction_name = 'acomp'
                 if not setu['convert_l2']: continue
 
         ## test if we have PGC bundle
         pgc_bundle = False
         if meta['PGC']:
             pgc_bundle = True
-            if meta['PGC_STRETCH'] in ['mr']:
+            if meta['PGC_STRETCH'] != 'ns': ## Assume all values except 'ns' (no stretch) indicate image has been corrected
                 print('Image {} is already corrected by supplier.'.format(bundle))
                 print('PGC_STRETCH: {}'.format(meta['PGC_STRETCH']))
                 atmospherically_corrected = True
+                correction_name = meta['PGC_STRETCH']
                 if not setu['convert_l2']: continue
 
         ## parse the metadata
@@ -550,7 +552,7 @@ def l1_convert(inputfile, output = None, inputfile_swir = None, settings = None)
 
             ## set up dataset attributes
             ds = 'rhot_{}'.format(rsrd['wave_name'][band])
-            if atmospherically_corrected: ds = ds.replace('rhot_', 'rhos_acomp_')
+            if atmospherically_corrected: ds = ds.replace('rhot_', f'rhos_{correction_name}_')
 
             ds_att = {'wavelength': rsrd['wave_mu'][band]*1000, 'band_name': band, 'f0': f0_b[band]/10.}
             if gains != None:

--- a/acolite/worldview/l1_convert.py
+++ b/acolite/worldview/l1_convert.py
@@ -295,7 +295,8 @@ def l1_convert(inputfile, output = None, inputfile_swir = None, settings = None)
                 lats = [meta['BAND_INFO'][bt][k] for k in meta['BAND_INFO'][bt] if 'LAT' in k]
                 lim = [min(lats), min(lons), max(lats), max(lons)]
             dct, nc_projection, warp_to = ac.shared.projection_setup(lim, setu['worldview_reproject_resolution'], \
-                                                                          res_method=setu['worldview_reproject_method'])
+                                                                          res_method=setu['worldview_reproject_method'],
+                                                                          add_half_pixel=True)
             global_dims = dct['ydim'], dct['xdim']
 
         ## final scene dimensions
@@ -348,7 +349,7 @@ def l1_convert(inputfile, output = None, inputfile_swir = None, settings = None)
             for k in ['xrange', 'yrange', 'proj4_string', 'pixel_size', 'dimensions', 'zone']:
                 if k in dct: gatts[k] = dct[k]
 
-            if nc_projection is None: nc_projection = ac.shared.projection_netcdf(dct, add_half_pixel = False)
+            if nc_projection is None: nc_projection = ac.shared.projection_netcdf(dct, add_half_pixel = True)
             gatts['projection_key'] = [k for k in nc_projection if k not in ['x', 'y']][0]
 
         ## write results to output file

--- a/acolite/worldview/l1_convert.py
+++ b/acolite/worldview/l1_convert.py
@@ -21,7 +21,7 @@
 
 def l1_convert(inputfile, output = None, inputfile_swir = None, settings = None):
 
-    import os, glob, dateutil.parser, datetime, time
+    import os, glob, dateutil.parser, datetime, time, re
     import numpy as np
     import scipy.interpolate
     import acolite as ac
@@ -79,9 +79,15 @@ def l1_convert(inputfile, output = None, inputfile_swir = None, settings = None)
 
         ## test if we have the pan bundle as well
         pan_bundle = None
-        if bundle.endswith('MUL') & (not setu['worldview_skip_pan']):
+        if bundle.endswith('MUL') and (not setu['worldview_skip_pan']):
             if os.path.exists(bundle[0:-3] + 'PAN'):
                 pan_bundle = bundle[0:-3] + 'PAN'
+        elif meta["PGC"] and not setu['worldview_skip_pan']:
+            ## Try to find the pan bundle using PGC naming conventions
+            match = re.search(r"-(\w\d\w\w)-", bundle)
+            if match:
+                prod_code = match.group(1)
+                pan_bundle = bundle.replace(prod_code, "P1BS")
 
         pan_meta = None
         if (pan_bundle is not None):
@@ -436,7 +442,10 @@ def l1_convert(inputfile, output = None, inputfile_swir = None, settings = None)
                 if pan_bundle is not None:
                     for tile_mdata_pan in pan_meta['TILE_INFO']:
                         if tile in tile_mdata_pan['FILENAME']:
-                            pan_file = '{}/{}'.format(pan_bundle,tile_mdata_pan['FILENAME'])
+                            if os.path.isdir(bundle):
+                                pan_file = '{}/{}'.format(pan_bundle,tile_mdata_pan['FILENAME'])
+                            else:
+                                pan_file = pan_bundle
                         if not os.path.exists(pan_file):
                             continue
                     ## full resolution pan output

--- a/acolite/worldview/l1_convert.py
+++ b/acolite/worldview/l1_convert.py
@@ -478,9 +478,11 @@ def l1_convert(inputfile, output = None, inputfile_swir = None, settings = None)
                 if dtype == np.dtype('uint8'):
                     nodata = d == np.uint8(0)
                 elif dtype == np.dtype('uint16'):
-                    nodata = d == np.uint16(0)
+                    nodata_value = 0 if not pgc_bundle else 65535
+                    nodata = d == np.uint16(nodata_value)
                 elif dtype == np.dtype('float32'):
-                    nodata = d == np.float32(0)
+                    nodata_value = 0 if not pgc_bundle else -9999
+                    nodata = d == np.float32(nodata_value)
 
                 ## override cf for PGC bundle
                 if pgc_bundle:

--- a/acolite/worldview/l1_convert.py
+++ b/acolite/worldview/l1_convert.py
@@ -206,7 +206,10 @@ def l1_convert(inputfile, output = None, inputfile_swir = None, settings = None)
             except:
                 tile = ''
 
-            file = '{}/{}'.format(bundle,tile_mdata['FILENAME'])
+            if os.path.isdir(bundle):
+                file = '{}/{}'.format(bundle,tile_mdata['FILENAME'])
+            else:
+                file = bundle
 
             ## check if the files were named .TIF instead of .TIFF
             if not os.path.exists(file): file = file.replace('.TIFF', '.TIF')
@@ -399,7 +402,10 @@ def l1_convert(inputfile, output = None, inputfile_swir = None, settings = None)
                 offset = [int(tile_mdata['ULCOLOFFSET']), int(tile_mdata['ULROWOFFSET'])]
                 if verbosity > 1: print('{} - Band {} Processing tile {}/{}'.format(datetime.datetime.now().isoformat()[0:19], band, ti+1, ntiles), tile, offset)
 
-                file = '{}/{}'.format(bundle,tile_mdata['FILENAME'])
+                if os.path.isdir(bundle):
+                    file = '{}/{}'.format(bundle,tile_mdata['FILENAME'])
+                else:
+                    file = bundle
                 ## check if the files were named .TIF instead of .TIFF
                 if not os.path.exists(file): file = file.replace('.TIFF', '.TIF')
                 if not os.path.exists(file): continue

--- a/acolite/worldview/metadata_parse.py
+++ b/acolite/worldview/metadata_parse.py
@@ -61,6 +61,11 @@ def metadata_parse(metafile):
             band_indices=[1,2,3,4]
             band_tag_names = ["BAND_B", "BAND_G", "BAND_R", "BAND_N"]
 
+            ## add PAN band
+            band_names += ['PAN']
+            band_indices += [1]
+            band_tag_names += ['BAND_P']
+
         if metadata['SATID'] == 'WV03':
             metadata['satellite'] = 'WorldView3'
             metadata['sensor'] = 'WorldView3'
@@ -71,6 +76,12 @@ def metadata_parse(metafile):
                           1,2,3,4,5,6,7,8]
             band_tag_names = ["BAND_C","BAND_B","BAND_G","BAND_Y","BAND_R","BAND_RE","BAND_N", "BAND_N2",
                               "BAND_S1", "BAND_S2", "BAND_S3", "BAND_S4", "BAND_S5", "BAND_S6", "BAND_S7", "BAND_S8"]
+
+            ## add PAN band
+            band_names += ['PAN']
+            band_indices += [1]
+            band_tag_names += ['BAND_P']
+
         if metadata['SATID'] == 'WV02':
             metadata['satellite'] = 'WorldView2'
             metadata['sensor'] = 'WorldView2'

--- a/acolite/worldview/metadata_parse.py
+++ b/acolite/worldview/metadata_parse.py
@@ -11,6 +11,7 @@
 ##                2025-02-14 (QV) added Legion
 ##                2025-03-01 (QV) added PGC and PGC stretch identification
 ##                2025-03-31 (QV) added WV4 support
+##                2026-06-11 (DP) ignore XML namespaces if present for forward metadata compatibility
 
 def metadata_parse(metafile):
     import os, sys, fnmatch, dateutil.parser
@@ -30,10 +31,10 @@ def metadata_parse(metafile):
 
     ## check if PGC image
     metadata['PGC'] = False
-    node = xmldoc.getElementsByTagName('PGC_IMD')
+    node = xmldoc.getElementsByTagNameNS('*', 'PGC_IMD')
     if len(node) > 0:
         metadata['PGC'] = True
-        node = xmldoc.getElementsByTagName('STRETCH')
+        node = xmldoc.getElementsByTagNameNS('*', 'STRETCH')
         metadata['PGC_STRETCH'] = node[0].firstChild.nodeValue
 
     ## get image information
@@ -49,7 +50,7 @@ def metadata_parse(metafile):
                     "RADIOMETRICLEVEL", "RADIOMETRICENHANCEMENT"]
 
     for tag in metadata_tags:
-        node = xmldoc.getElementsByTagName(tag)
+        node = xmldoc.getElementsByTagNameNS('*', tag)
         if len(node) > 0: metadata[tag] = node[0].firstChild.nodeValue
 
     if 'SATID' in metadata:
@@ -149,9 +150,9 @@ def metadata_parse(metafile):
         #if band_tag == 'BAND_S1': band_index = 1 # reset counter for SWIR bands
         band_data = {'name':band_names[b], 'index':band_indices[b]}
         ## there are two tags in WV3 metadata
-        for t in xmldoc.getElementsByTagName(band_tag):
+        for t in xmldoc.getElementsByTagNameNS('*', band_tag):
             for tag in band_tags:
-                    node = t.getElementsByTagName(tag)
+                    node = t.getElementsByTagNameNS('*', tag)
                     if len(node) > 0:
                         band_data[tag]=float(node[0].firstChild.nodeValue)
         if len(band_data)>2: ## keep band only if in metadata
@@ -171,10 +172,10 @@ def metadata_parse(metafile):
                 "ULX","ULY","URX","URY",
                 "LRX","LRY","LLX","LLY"]
     tile_values=[]
-    for t in xmldoc.getElementsByTagName('TILE'):
+    for t in xmldoc.getElementsByTagNameNS('*', 'TILE'):
         tile = {}
         for tag in tile_tags:
-                node = t.getElementsByTagName(tag)
+                node = t.getElementsByTagNameNS('*', tag)
                 if len(node) > 0:
                     if tag == "FILENAME": val=node[0].firstChild.nodeValue
                     else: val=float(node[0].firstChild.nodeValue)


### PR DESCRIPTION
These improvements primarily seek to allow creation of L1R NetCDF from WorldView imagery distributed by PGC or pre-processed with PGC tools. 

Changes include:

- Handle the case where `bundle` is a file (PGC distribution) as well as a directory (vendor distribution)
- Expand the `PGC_STRETCH` values that ACOLITE recognizes as already corrected and revise NetCDF variable naming to reflect correction name
- Handle NoData values in PGC distributed/process imagery
- Enable `add_half_pixel` feature when interpreting image coordinates for correct GeoTiff output
- Revise GeoTiff export to correctly encode `NaN` in NetCDF as `NaN` in GeoTiff
- Extend XML tag reading to handle an upcoming change to vendor's metadata 

Delivery of data for testing will be coordinated via email.